### PR TITLE
Build flags for macos

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CC=g++
-CFLAGS=-I.
+CFLAGS=-I. -std=c++11
 LFLAGS=-lntl -lgmp
 DEPS = sha256.h sha512.h
 


### PR DESCRIPTION
By default, MacOS uses a legacy version of libc that is not compatible with c++11